### PR TITLE
Update process_tdl_files.py

### DIFF
--- a/MTWSPy/post_processing/process_tdl_files.py
+++ b/MTWSPy/post_processing/process_tdl_files.py
@@ -118,12 +118,12 @@ def process_one_file(input_dict):
                 # Compute the midpoint
                 m = l.Position(0.5 * l.s13)
 
-                mp_df['dist'][index] = np.round(distdg,3)
-                mp_df['az'][index] = np.round(az,3)
-                mp_df['baz'][index] = np.round(baz,3)
+                mp_df.loc[index, "dist"] = np.round(distdg,3)
+                mp_df.loc[index, "az"] = np.round(az,3)
+                mp_df.loc[index, "baz"] = np.round(baz,3)
 
-                mp_df['mid_lat'][index] = np.round(m['lat2'],3)
-                mp_df['mid_lon'][index] = np.round(m['lon2'],3)
+                mp_df.loc[index, "mid_lat"] = np.round(m['lat2'],3)
+                mp_df.loc[index, "mid_lon"] = np.round(m['lon2'],3)
             
             # Merge the dataframes
             tdl_df = pd.merge(tdl_df, mp_df, left_index = True, right_index = True)


### PR DESCRIPTION
Fix to ChainedAssignmentError to future proof for pandas 3..0 Lines 121-126 are affected.

Error:

/home/aboyce/s_seismology/MTWSPy_code/MTWSPy/process_tdl_files.py:122: FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0! You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy. A typical example is when you are setting values in a column of a DataFrame, like:

df["col"][row_indexer] = value

Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy